### PR TITLE
remove deprecated flag

### DIFF
--- a/docs/_docs/workshop/deploy.md
+++ b/docs/_docs/workshop/deploy.md
@@ -186,6 +186,6 @@ You can creat a new yaml file from scratch if you want. Altough real dev oppers 
 <div markdown="1">>
 `kubectl create deployment --image=torklo/workshop-frontend ez-frontend`
 
-You should save the generated deployment as a yaml file: `kubectl get deployment ez-frontend -o yaml --export > frontend-deployment.yaml`
+You should save the generated deployment as a yaml file: `kubectl get deployment ez-frontend -o yaml > frontend-deployment.yaml`
 </div>
 </details>


### PR DESCRIPTION
--export is deprecated apparently and you can run the command without it i guess.